### PR TITLE
Add project search with autocomplete and pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cursor/
 backup-dbs/
 .idea/
 *.sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 **Fixed** for any bug fixes.
 **Security** in case of vulnerabilities.
 
+
+## [0.4.4] - 2025-02-08
+### Added
+- Project search functionality with autocomplete
+- Pagination for projects list page
+
 ## [0.4.3] - 2025-01-15
 ### Added
 - Testimonials on Ad pagee

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
 
+from . import views
 from .views import CreateLikeProjectAPIView, UpdateLikeProjectAPIView
 
 urlpatterns = [
     path("like/", CreateLikeProjectAPIView.as_view()),
     path("like/<int:pk>/", UpdateLikeProjectAPIView.as_view()),
+    path("search/projects/", views.search_projects, name="api_search_projects"),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,11 @@
+from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import generics
+from rest_framework import generics, viewsets
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
-from projects.models import Like
+from projects.models import Like, Project
 
 from .serializers import LikeSerializer, LikeSerializerNoId
 
@@ -16,3 +20,29 @@ class CreateLikeProjectAPIView(generics.ListCreateAPIView):
 class UpdateLikeProjectAPIView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Like.objects.all()
     serializer_class = LikeSerializerNoId
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def search_projects(request):
+    query = request.GET.get("q", "")
+    if not query:
+        return Response([])
+
+    projects = Project.objects.filter(
+        Q(title__icontains=query) | Q(short_description__icontains=query), published=True, active=True
+    ).order_by("-sponsored", "-updated_date")[:5]
+
+    results = [
+        {
+            "id": project.id,
+            "title": project.title,
+            "slug": project.slug,
+            "short_description": project.short_description,
+            "screenshot": project.homepage_screenshot.url if project.homepage_screenshot else None,
+            "url": project.url,
+        }
+        for project in projects
+    ]
+
+    return Response(results)

--- a/blog/models.py
+++ b/blog/models.py
@@ -8,7 +8,11 @@ from model_utils.models import TimeStampedModel
 class Post(TimeStampedModel):
     title = models.CharField(max_length=250)
     description = models.TextField(blank=True)
-    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="post")
+    author = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="post",
+    )
     slug = models.SlugField(max_length=250)
     tags = models.ManyToManyField("Tag", related_name="post", blank=True)
     unsplashID = models.CharField(max_length=40, blank=True)

--- a/frontend/src/controllers/search_controller.js
+++ b/frontend/src/controllers/search_controller.js
@@ -1,0 +1,151 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ["input", "results"];
+    static values = {
+        url: String,
+        debounce: { type: Number, default: 300 }
+    };
+
+    initialize() {
+        this.debouncedSearch = this.debounce(this.search.bind(this), this.debounceValue);
+        this.onClickOutside = this.onClickOutside.bind(this);
+        this.handleKeyPress = this.handleKeyPress.bind(this);
+        this.selectedIndex = -1;
+        document.addEventListener("click", this.onClickOutside);
+        document.addEventListener("keydown", this.handleKeyPress);
+    }
+
+    disconnect() {
+        document.removeEventListener("click", this.onClickOutside);
+        document.removeEventListener("keydown", this.handleKeyPress);
+    }
+
+    handleKeyPress(event) {
+        // Focus search on '/' key press
+        if (event.key === "/" && document.activeElement !== this.inputTarget) {
+            event.preventDefault();
+            this.inputTarget.focus();
+            return;
+        }
+
+        // Handle arrow keys and enter only when results are visible
+        if (this.resultsTarget.classList.contains("hidden")) {
+            return;
+        }
+
+        const results = this.resultsTarget.querySelectorAll("a");
+        if (!results.length) return;
+
+        switch (event.key) {
+            case "ArrowDown":
+                event.preventDefault();
+                this.selectedIndex = Math.min(this.selectedIndex + 1, results.length - 1);
+                this.updateSelection(results);
+                break;
+
+            case "ArrowUp":
+                event.preventDefault();
+                this.selectedIndex = Math.max(this.selectedIndex - 1, -1);
+                this.updateSelection(results);
+                break;
+
+            case "Enter":
+                event.preventDefault();
+                if (this.selectedIndex >= 0) {
+                    results[this.selectedIndex].click();
+                }
+                break;
+
+            case "Escape":
+                event.preventDefault();
+                this.hideResults();
+                break;
+        }
+    }
+
+    updateSelection(results) {
+        results.forEach((result, index) => {
+            if (index === this.selectedIndex) {
+                result.classList.add("bg-gray-50");
+                result.scrollIntoView({ block: "nearest" });
+            } else {
+                result.classList.remove("bg-gray-50");
+            }
+        });
+    }
+
+    onClickOutside(event) {
+        if (!this.element.contains(event.target)) {
+            this.hideResults();
+        }
+    }
+
+    onInput(event) {
+        const query = event.target.value.trim();
+        if (query.length < 1) {
+            this.hideResults();
+            return;
+        }
+        this.selectedIndex = -1;
+        this.debouncedSearch(query);
+    }
+
+    async search(query) {
+        try {
+            const response = await fetch(`${this.urlValue}?q=${encodeURIComponent(query)}`, {
+                headers: {
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json();
+            this.showResults(data.slice(0, 3));
+        } catch (error) {
+            console.error("Search error:", error);
+            this.hideResults();
+        }
+    }
+
+    showResults(results) {
+        if (!results.length) {
+            this.resultsTarget.innerHTML = `
+                <div class="p-4 text-sm text-gray-500">
+                    No projects found
+                </div>
+            `;
+            this.resultsTarget.classList.remove("hidden");
+            return;
+        }
+
+        this.resultsTarget.innerHTML = results.map(result => `
+            <a href="/projects/${result.slug}"
+               class="flex flex-col p-4 border-b border-gray-100 hover:bg-gray-50 last:border-b-0">
+                <div class="font-medium text-gray-900">${result.title}</div>
+                <div class="text-sm text-gray-500">${result.short_description}</div>
+            </a>
+        `).join("");
+
+        this.resultsTarget.classList.remove("hidden");
+    }
+
+    hideResults() {
+        this.resultsTarget.classList.add("hidden");
+        this.selectedIndex = -1;
+    }
+
+    debounce(func, wait) {
+        let timeout;
+        return function executedFunction(...args) {
+            const later = () => {
+                clearTimeout(timeout);
+                func(...args);
+            };
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+        };
+    }
+}

--- a/projects/views.py
+++ b/projects/views.py
@@ -20,6 +20,7 @@ class ProjectListView(FilterView):
     model = Project
     template_name = "projects/all_projects.html"
     filterset_class = ProjectFilter
+    paginate_by = 12
 
     def get_queryset(self):
         queryset = Project.objects.filter(published=True, active=True).order_by("-sponsored", "-updated_date")

--- a/templates/projects/all_projects.html
+++ b/templates/projects/all_projects.html
@@ -30,6 +30,7 @@
     <div>
         <div class="flex justify-between items-center pb-4 sm:mb-0">
             <div class="flex justify-start items-center space-x-2">
+
               <div data-controller="dropdown" class="inline-block relative text-left">
                   <div>
                       <button type="button"
@@ -88,6 +89,21 @@
                       </form>
                   </div>
               </div>
+
+              <div data-controller="search"
+                  data-search-url-value="/api/v1/search/projects/"
+                  class="relative">
+                <input type="text"
+                        data-search-target="input"
+                        data-action="input->search#onInput"
+                        placeholder="Search projects (Press '/' to focus)"
+                        class="block p-3 w-64 text-gray-900 bg-white rounded-md border border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                >
+                <div data-search-target="results"
+                      class="hidden overflow-hidden absolute left-0 z-10 mt-2 w-96 bg-white rounded-md shadow-lg">
+                </div>
+            </div>
+
             </div>
             <div>
                 <a type="button"
@@ -98,7 +114,7 @@
             </div>
         </div>
         <div class="grid grid-cols-1 gap-6 mb-10 lg:grid-cols-3 md:grid-cols-2">
-            {% for site in filter.qs %}
+            {% for site in page_obj %}
                 <div
                   class="
                     flex flex-col justify-start bg-white rounded border-solid
@@ -160,6 +176,28 @@
                 </div>
             {% endfor %}
         </div>
+
+        {% if is_paginated %}
+        <div class="flex justify-center items-center mt-8 space-x-4">
+            {% if page_obj.has_previous %}
+                <a href="?{% if request.GET.order_by %}order_by={{ request.GET.order_by }}&{% endif %}{% if request.GET.is_open_source %}is_open_source={{ request.GET.is_open_source }}&{% endif %}page={{ page_obj.previous_page_number }}"
+                   class="px-4 py-2 text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 hover:bg-gray-50">
+                    Previous
+                </a>
+            {% endif %}
+
+            <span class="text-sm text-gray-700">
+                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+            </span>
+
+            {% if page_obj.has_next %}
+                <a href="?{% if request.GET.order_by %}order_by={{ request.GET.order_by }}&{% endif %}{% if request.GET.is_open_source %}is_open_source={{ request.GET.is_open_source }}&{% endif %}page={{ page_obj.next_page_number }}"
+                   class="px-4 py-2 text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 hover:bg-gray-50">
+                    Next
+                </a>
+            {% endif %}
+        </div>
+        {% endif %}
     </div>
 {% endblock content %}
 {% block schema %}


### PR DESCRIPTION
This commit adds search functionality with autocomplete to the projects list page, along with pagination support to improve performance and usability.

Key changes:
- Implemented a new search API endpoint that filters projects by title and description
- Added a Stimulus search controller with debounced autocomplete, keyboard navigation, and accessibility features like keyboard shortcuts
- Integrated pagination on the projects list page (12 items per page) with proper filter parameter handling
- Added search UI with dropdown results in the projects list header
- Updated API serialization to include relevant project preview data
- Ensured search results are ordered by sponsored status and update date
- Search supports keyboard navigation (arrows, enter, escape) and focus shortcut (/)

The search and pagination features make it easier for users to find relevant projects while improving performance by limiting result set sizes.